### PR TITLE
define screenshot options public

### DIFF
--- a/percy-xcui/Sources/PercyXcui/util/ScreenshotOptions.swift
+++ b/percy-xcui/Sources/PercyXcui/util/ScreenshotOptions.swift
@@ -1,10 +1,10 @@
 import Foundation
 
 public class ScreenshotOptions {
-  var statusBarHeight: Int = -1
-  var navigationBarHeight: Int = -1
+  public var statusBarHeight: Int = -1
+  public var navigationBarHeight: Int = -1
 
-  var fullScreen: Bool = false
+  public var fullScreen: Bool = false
 
   public init() {
   }


### PR DESCRIPTION
we are getting following error when trying to set options: `'statusBarHeight' is inaccessible due to 'internal' protection level`
Everything in swift is internal by default unless set otherwise.