### PR TITLE
Allow configuring a different hostname than “percy.cli”

### DIFF
--- a/percy-xcui/Sources/PercyXcui/AppPercy.swift
+++ b/percy-xcui/Sources/PercyXcui/AppPercy.swift
@@ -14,8 +14,13 @@ public class AppPercy {
   let cliWrapper: CliWrapper
   var isPercyEnabled: Bool
 
-  public init() {
-    self.cliWrapper = CliWrapper()
+  public init(percyCLIHostname: String? = nil) {
+    if let percyCLIHostname {
+      self.cliWrapper = CliWrapper(serverHostname: percyCLIHostname)
+    } else {
+      self.cliWrapper = CliWrapper()
+    }
+
     self.isPercyEnabled = cliWrapper.healthcheck()
   }
 

--- a/percy-xcui/Sources/PercyXcui/util/CliWrapper.swift
+++ b/percy-xcui/Sources/PercyXcui/util/CliWrapper.swift
@@ -2,7 +2,15 @@ import Foundation
 
 public class CliWrapper {
   // swiftlint:disable:next identifier_name
-  var PERCY_SERVER_ADDRESS: String = "http://percy.cli:5338"
+  var PERCY_SERVER_ADDRESS: String
+
+  init(
+    serverHostname: String = CliWrapper.PERCY_SERVER_DEFAULT_HOSTNAME
+  ) {
+    self.PERCY_SERVER_ADDRESS = "http://\(serverHostname):5338"
+  }
+
+  static var PERCY_SERVER_DEFAULT_HOSTNAME = "percy.cli"
 
   public func healthcheck() -> Bool {
     var ret: Bool = false


### PR DESCRIPTION
In environments where access to `/etc/hosts` isn't permitted (like Xcode Cloud) having the hostname for the CLI hard-coded makes it quite hard to use this library at the moment.

So to remedy that I added an argument to the initialiser for the AppPercy class allowing customisation of the hostname, if nil is sent (which is the default argument value) the default hostname "percy.cli" will be used like before, making this a non breaking change for the library consumer.