### PR TITLE
test: add host unit tests + CI coverage gate (95.7%, simulator path to ~100%)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,63 @@
+name: Test & Coverage
+
+on:
+  push:
+    branches: ["master", "main"]
+  pull_request:
+    branches: ["master", "main"]
+
+jobs:
+  # Blocking gate: builds the SwiftPM package on the macOS host and runs the
+  # Swift Testing unit suite with code coverage. Covers all of the SDK's
+  # host-testable logic (device mapping, JSON building, CLI-wrapper HTTP,
+  # logging, options, errors). The coverage floor is enforced by the script.
+  unit-coverage:
+    name: Unit tests + coverage gate
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Show Swift / Xcode versions
+        run: |
+          swift --version
+          xcodebuild -version || true
+
+      - name: Build package
+        run: swift build
+
+      - name: Run unit tests + enforce coverage floor
+        run: ./Scripts/coverage.sh
+
+  # Informational (non-blocking): exercises the iOS-runtime paths that cannot
+  # run on the host -- the screenshot-capture pipeline in GenericProvider /
+  # ScreenshotController -- via the existing XCUITests on an iOS simulator.
+  # Marked continue-on-error because simulator availability and SPM dependency
+  # resolution for the .xcodeproj can vary across runner images; it raises real
+  # coverage toward 100% without being able to fail the required gate.
+  simulator-uitests:
+    name: Simulator XCUITests (informational)
+    runs-on: macos-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: List available simulators
+        run: xcrun simctl list devices available
+
+      - name: Run XCUITests with coverage on a simulator
+        run: |
+          set -o pipefail
+          # Pick the first available iPhone simulator on the runner image.
+          DEVICE="$(xcrun simctl list devices available \
+            | grep -Eo 'iPhone [0-9][^(]*' | head -1 | sed 's/[[:space:]]*$//')"
+          echo "Using simulator: ${DEVICE:-iPhone 15}"
+          xcodebuild test \
+            -project percy-xcui-sdk.xcodeproj \
+            -scheme percy-xcui-sdk \
+            -destination "platform=iOS Simulator,name=${DEVICE:-iPhone 15}" \
+            -enableCodeCoverage YES \
+            -resultBundlePath TestResults.xcresult || true
+
+      - name: Report PercyXcui coverage from the simulator run
+        run: |
+          xcrun xccov view --report --only-targets TestResults.xcresult || true

--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,10 @@ import PackageDescription
 
 let package = Package(
     name: "Percy XCUI Swift",
+    // macOS platform is declared so the host unit-test suite (Swift Testing)
+    // can run via `swift test`. The shipped library remains iOS-targeted; this
+    // does not change what iOS clients build.
+    platforms: [.macOS(.v13)],
     products: [
         .library(
             name: "PercyXcui",
@@ -14,6 +18,11 @@ let package = Package(
         .target(
             name: "PercyXcui",
             // Note: This contains inner folder as path so that other clients can use this repo as a package
-            path: "percy-xcui/Sources")
+            path: "percy-xcui/Sources"),
+        .testTarget(
+            name: "PercyXcuiTests",
+            dependencies: ["PercyXcui"],
+            // Shares the one canonical suite that also lives in percy-xcui/Package.swift.
+            path: "percy-xcui/Tests/PercyXcuiTests")
     ]
 )

--- a/Scripts/coverage.sh
+++ b/Scripts/coverage.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# Runs the PercyXcui host unit-test suite (Swift Testing) with code coverage,
+# then enforces a minimum line-coverage threshold via llvm-cov.
+#
+# Why this exists
+#   The shipped SDK targets iOS, but its pure logic (device mapping, JSON
+#   building, CLI wrapper HTTP, logging, options/errors) is exercised on the
+#   macOS host through `#if canImport(UIKit)` fallbacks. Lines that genuinely
+#   require the iOS runtime (the screenshot-capture pipeline in
+#   GenericProvider / ScreenshotController) cannot run on the host and are
+#   covered by the simulator XCUITests instead. The host floor is therefore
+#   below 100% by design; see COVERAGE_FLOOR below.
+#
+# Toolchain handling
+#   Swift Testing ships in the toolchain. On a runner WITHOUT full Xcode
+#   (Command Line Tools only) the Testing.framework / interop dylib are not on
+#   the default search path, so we add them explicitly and pin an rpath. When
+#   full Xcode is present `swift test` finds them natively and no extra flags
+#   are needed.
+#
+# Usage: Scripts/coverage.sh [floor_percent]
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Minimum acceptable host line coverage. The achieved host figure is ~95.7%;
+# the remaining lines are the iOS-runtime screenshot pipeline (simulator-only)
+# plus two defensive branches Foundation cannot trigger without aborting. The
+# floor is set to the honest host maximum.
+COVERAGE_FLOOR="${1:-95.0}"
+
+EXTRA_FLAGS=()
+if ! xcrun --find xctest >/dev/null 2>&1; then
+  # Command Line Tools only: locate Swift Testing's framework + interop dylib.
+  DEV_DIR="$(xcode-select -p)"
+  FW_DIR="$DEV_DIR/Library/Developer/Frameworks"
+  LIB_DIR="$DEV_DIR/Library/Developer/usr/lib"
+  if [[ -d "$FW_DIR" ]]; then
+    echo "Command Line Tools detected; adding Swift Testing search paths."
+    EXTRA_FLAGS+=(
+      -Xswiftc -F -Xswiftc "$FW_DIR"
+      -Xlinker -F -Xlinker "$FW_DIR"
+      -Xlinker -rpath -Xlinker "$FW_DIR"
+      -Xlinker -rpath -Xlinker "$LIB_DIR"
+    )
+  fi
+fi
+
+echo "Running unit tests with code coverage..."
+# --no-parallel: the suites share process-global state (a registered
+# URLProtocol stub and AppPercy's static config), so cross-suite parallelism
+# must be disabled for deterministic results.
+swift test --enable-code-coverage --no-parallel "${EXTRA_FLAGS[@]}"
+
+BIN_PATH="$(swift build --show-bin-path)"
+PROFDATA="$BIN_PATH/codecov/default.profdata"
+
+# Resolve the test bundle's executable (name contains spaces).
+BUNDLE="$(/usr/bin/find "$BIN_PATH" -maxdepth 1 -name '*.xctest' -print -quit)"
+if [[ "$(uname)" == "Darwin" ]]; then
+  EXEC="$BUNDLE/Contents/MacOS/$(basename "$BUNDLE" .xctest)"
+else
+  EXEC="$BUNDLE"
+fi
+
+echo ""
+echo "Coverage report (source only):"
+xcrun llvm-cov report "$EXEC" \
+  -instr-profile "$PROFDATA" \
+  -ignore-filename-regex='(Tests|\.build)/.*'
+
+PERCENT="$(xcrun llvm-cov export "$EXEC" \
+  -instr-profile "$PROFDATA" \
+  -ignore-filename-regex='(Tests|\.build)/.*' \
+  -summary-only \
+  | python3 -c "import sys,json;print(json.load(sys.stdin)['data'][0]['totals']['lines']['percent'])")"
+
+echo ""
+printf 'Line coverage: %.2f%% (floor: %s%%)\n' "$PERCENT" "$COVERAGE_FLOOR"
+
+BELOW="$(python3 -c "import sys;print(1 if float('$PERCENT') < float('$COVERAGE_FLOOR') else 0)")"
+if [[ "$BELOW" == "1" ]]; then
+  echo "FAIL: line coverage is below the floor."
+  exit 1
+fi
+
+echo "PASS: line coverage meets the floor."

--- a/Scripts/coverage.sh
+++ b/Scripts/coverage.sh
@@ -51,7 +51,10 @@ echo "Running unit tests with code coverage..."
 # --no-parallel: the suites share process-global state (a registered
 # URLProtocol stub and AppPercy's static config), so cross-suite parallelism
 # must be disabled for deterministic results.
-swift test --enable-code-coverage --no-parallel "${EXTRA_FLAGS[@]}"
+# Use ${EXTRA_FLAGS[@]+"${EXTRA_FLAGS[@]}"} (not "${EXTRA_FLAGS[@]}") so an empty
+# array under `set -u` expands to nothing instead of erroring "unbound variable"
+# on macOS bash 3.2 — the full-Xcode CI runner leaves EXTRA_FLAGS empty.
+swift test --enable-code-coverage --no-parallel ${EXTRA_FLAGS[@]+"${EXTRA_FLAGS[@]}"}
 
 BIN_PATH="$(swift build --show-bin-path)"
 PROFDATA="$BIN_PATH/codecov/default.profdata"

--- a/percy-xcui-sdk.xcodeproj/xcshareddata/xcschemes/percy-xcui-sdk.xcscheme
+++ b/percy-xcui-sdk.xcodeproj/xcshareddata/xcschemes/percy-xcui-sdk.xcscheme
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1420"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "08B5090A29B8AA6D00F9B864"
+               BuildableName = "percy-xcui-sdk.app"
+               BlueprintName = "percy-xcui-sdk"
+               ReferencedContainer = "container:percy-xcui-sdk.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "08B5092429B8AA7000F9B864"
+               BuildableName = "percy-xcui-sdkUITests.xctest"
+               BlueprintName = "percy-xcui-sdkUITests"
+               ReferencedContainer = "container:percy-xcui-sdk.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "08B5090A29B8AA6D00F9B864"
+            BuildableName = "percy-xcui-sdk.app"
+            BlueprintName = "percy-xcui-sdk"
+            ReferencedContainer = "container:percy-xcui-sdk.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolsVersion = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "08B5090A29B8AA6D00F9B864"
+            BuildableName = "percy-xcui-sdk.app"
+            BlueprintName = "percy-xcui-sdk"
+            ReferencedContainer = "container:percy-xcui-sdk.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/percy-xcui/Package.swift
+++ b/percy-xcui/Package.swift
@@ -3,6 +3,10 @@ import PackageDescription
 
 let package = Package(
     name: "Percy XCUI Swift",
+    // macOS platform is declared so the host unit-test suite (Swift Testing)
+    // can run via `swift test`. The shipped library remains iOS-targeted; this
+    // does not change what iOS clients build.
+    platforms: [.macOS(.v13)],
     products: [
         .library(
             name: "PercyXcui",
@@ -14,6 +18,13 @@ let package = Package(
         .target(
             name: "PercyXcui",
             dependencies: []
+        ),
+        .testTarget(
+            name: "PercyXcuiTests",
+            dependencies: ["PercyXcui"],
+            // Canonical test sources live inside this nested package root so both
+            // Package.swift files can reference the same suite.
+            path: "Tests/PercyXcuiTests"
         )
     ]
 )

--- a/percy-xcui/Sources/PercyXcui/metadata/Metadata.swift
+++ b/percy-xcui/Sources/PercyXcui/metadata/Metadata.swift
@@ -1,6 +1,8 @@
 import Foundation
-import UIKit
-import XCTest
+#if canImport(UIKit)
+  import UIKit
+  import XCTest
+#endif
 
 internal class Metadata {
   var options: ScreenshotOptions
@@ -9,35 +11,52 @@ internal class Metadata {
     self.options = options
   }
 
+  // The device screen scale. On iOS this is `UIScreen.main.scale`; on a
+  // non-UIKit host (used only by the unit-test suite) it falls back to 1 so
+  // the pure scaling logic remains exercisable. Behaviour on iOS is unchanged.
+  func screenScale() -> CGFloat {
+    #if canImport(UIKit)
+      return UIScreen.main.scale
+    #else
+      return 1
+    #endif
+  }
+
   public func osName() -> String {
     return "iOS"
   }
 
   public func platformVersion() -> String {
-    return String(UIDevice.current.systemVersion.split(separator: ".").first ?? "")
+    #if canImport(UIKit)
+      return String(UIDevice.current.systemVersion.split(separator: ".").first ?? "")
+    #else
+      return String(ProcessInfo.processInfo.operatingSystemVersion.majorVersion)
+    #endif
   }
 
   public func orientation() -> String {
-    if XCUIDevice.shared.orientation.isLandscape {
-      return "landscape"
-    }
+    #if canImport(UIKit)
+      if XCUIDevice.shared.orientation.isLandscape {
+        return "landscape"
+      }
+    #endif
     // Note: we return default portait as sometimes orientation is unknown/flat as well
     return "portrait"
   }
 
   public func deviceScreenWidth() -> CGFloat {
-    return CGFloat(mapToDeviceWidth(identifier: deviceName().lowercased())) * UIScreen.main.scale
+    return CGFloat(mapToDeviceWidth(identifier: deviceName().lowercased())) * screenScale()
   }
 
   public func deviceScreenHeight() -> CGFloat {
-    return CGFloat(mapToDeviceHeight(identifier: deviceName().lowercased())) * UIScreen.main.scale
+    return CGFloat(mapToDeviceHeight(identifier: deviceName().lowercased())) * screenScale()
   }
 
   public func statBarHeight() -> Int {
     if options.statusBarHeight != -1 {
       return options.statusBarHeight
     }
-    return Int(CGFloat(mapToDeviceStatusBar(identifier: deviceName().lowercased())) * UIScreen.main.scale)
+    return Int(CGFloat(mapToDeviceStatusBar(identifier: deviceName().lowercased())) * screenScale())
   }
 
   public func navBarHeight() -> Int {
@@ -73,7 +92,7 @@ internal class Metadata {
 
   // swiftlint:disable:next cyclomatic_complexity function_body_length
   func mapToDevice(identifier: String) -> String {
-    #if os(iOS)
+    #if os(iOS) || (!os(tvOS) && !os(watchOS))
       switch identifier {
       case "iPod5,1": return "iPod touch (5th generation)"
       case "iPod7,1": return "iPod touch (6th generation)"
@@ -192,7 +211,12 @@ internal class Metadata {
     case "iphone 12 pro", "iphone 12": return 390
     case "iphone 11 pro max": return 418
     case "iphone 11": return 414
-    default: return Int(UIScreen.main.bounds.width)
+    default:
+      #if canImport(UIKit)
+        return Int(UIScreen.main.bounds.width)
+      #else
+        return 0
+      #endif
     }
   }
 
@@ -205,7 +229,12 @@ internal class Metadata {
     case "iphone 13 mini", "iphone 12 mini", "iphone 11 pro": return 812
     case "iphone 12 pro", "iphone 12": return 844
     case "iphone 11 pro max", "iphone 11": return 896
-    default: return Int(UIScreen.main.bounds.height)
+    default:
+      #if canImport(UIKit)
+        return Int(UIScreen.main.bounds.height)
+      #else
+        return 0
+      #endif
     }
   }
 }

--- a/percy-xcui/Sources/PercyXcui/providers/GenericProvider.swift
+++ b/percy-xcui/Sources/PercyXcui/providers/GenericProvider.swift
@@ -1,5 +1,7 @@
 import Foundation
-import UIKit
+#if canImport(UIKit)
+  import UIKit
+#endif
 
 public class GenericProvider {
   let cliWrapper: CliWrapper

--- a/percy-xcui/Sources/PercyXcui/util/ScreenshotController.swift
+++ b/percy-xcui/Sources/PercyXcui/util/ScreenshotController.swift
@@ -1,17 +1,30 @@
 import Foundation
-import UIKit
-import XCTest
+#if canImport(UIKit)
+  import UIKit
+  import XCTest
 
-public class ScreenshotController: UIViewController {
-  // swiftlint:disable:next unneeded_override
-  public override func viewDidLoad() {
-    super.viewDidLoad()
-  }
-
-  public func takeScreenshot() throws -> String {
-    guard let imageData = XCUIScreen.main.screenshot().image.pngData() else {
-      throw AppPercyError.screenshotError("Failed to take screenshot")
+  public class ScreenshotController: UIViewController {
+    // swiftlint:disable:next unneeded_override
+    public override func viewDidLoad() {
+      super.viewDidLoad()
     }
-    return imageData.base64EncodedString()
+
+    public func takeScreenshot() throws -> String {
+      guard let imageData = XCUIScreen.main.screenshot().image.pngData() else {
+        throw AppPercyError.screenshotError("Failed to take screenshot")
+      }
+      return imageData.base64EncodedString()
+    }
   }
-}
+#else
+  // Host (non-UIKit) build used only by the unit-test suite. `XCUIScreen` and
+  // `UIViewController` are unavailable off-device, so the host shim throws the
+  // same error type the iOS path raises on failure. iOS behaviour is unchanged.
+  public class ScreenshotController {
+    public init() {}
+
+    public func takeScreenshot() throws -> String {
+      throw AppPercyError.screenshotError("Screenshot capture requires the iOS runtime")
+    }
+  }
+#endif

--- a/percy-xcui/Tests/PercyXcuiTests/AppPercyTests.swift
+++ b/percy-xcui/Tests/PercyXcuiTests/AppPercyTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import Testing
+
+@testable import PercyXcui
+
+/// Serialized: these tests mutate `AppPercy`'s shared static config and the
+/// registered `URLProtocol` stub.
+@Suite(.serialized)
+struct AppPercyTests {
+  init() {
+    StubURLProtocol.register()
+    StubURLProtocol.reset()
+    Log.logLevel = "debug"
+    resetConfig()
+  }
+
+  private func resetConfig() {
+    AppPercy.ignoreErrors = true
+    AppPercy.allowedDevices = []
+    AppPercy._allowedDevicesMessageShown = false
+    AppPercy.percyCLIHostname = "percy.cli"
+    AppPercy.percyCLIPort = 5338
+  }
+
+  private func teardown() {
+    StubURLProtocol.unregister()
+    resetConfig()
+  }
+
+  private func enableHealthcheck() {
+    StubURLProtocol.stubs["/percy/healthcheck"] = .init(
+      statusCode: 204, headers: [:], body: nil, error: nil)
+  }
+
+  @Test func setLogLevel() {
+    defer { teardown() }
+    let percy = AppPercy()
+    percy.setLogLevel(level: "error")
+    #expect(Log.logLevel == "error")
+    percy.setLogLevel()
+    #expect(Log.logLevel == "info")
+  }
+
+  @Test func screenshotDisabledWhenCLINotRunning() throws {
+    defer { teardown() }
+    // No healthcheck stub -> connection fails -> isPercyEnabled false ->
+    // screenshot() returns early without touching the provider.
+    let percy = AppPercy()
+    #expect(percy.isPercyEnabled == false)
+    try percy.screenshot(name: "abc")
+  }
+
+  @Test func screenshotEnabledSwallowsErrorByDefault() throws {
+    defer { teardown() }
+    enableHealthcheck()
+    let percy = AppPercy()
+    #expect(percy.isPercyEnabled == true)
+    // Host ScreenshotController throws; ignoreErrors defaults to true so this
+    // is logged and swallowed (no rethrow).
+    try percy.screenshot(name: "abc")
+  }
+
+  @Test func screenshotEnabledRethrowsWhenIgnoreErrorsFalse() {
+    defer { teardown() }
+    enableHealthcheck()
+    let percy = AppPercy()
+    AppPercy.ignoreErrors = false
+    #expect(throws: AppPercyError.self) {
+      try percy.screenshot(name: "abc")
+    }
+  }
+
+  @Test func screenshotSkippedWhenDeviceNotAllowed() throws {
+    defer { teardown() }
+    enableHealthcheck()
+    let percy = AppPercy()
+    AppPercy.ignoreErrors = false
+    AppPercy.allowedDevices = ["Definitely Not This Device"]
+    // isDeviceAllowed() returns false -> screenshot returns early, provider
+    // never runs, so no error is thrown even with ignoreErrors=false.
+    try percy.screenshot(name: "abc")
+    // Second call exercises the already-shown branch (message not re-logged).
+    try percy.screenshot(name: "abc")
+    #expect(AppPercy._allowedDevicesMessageShown == true)
+  }
+
+  @Test func screenshotAllowedWhenDeviceInAllowedList() throws {
+    defer { teardown() }
+    enableHealthcheck()
+    let percy = AppPercy()
+    // Add the current device to the allowed list so isDeviceAllowed() == true.
+    AppPercy.allowedDevices = [Metadata().deviceName()]
+    // Reaches the provider (which throws on host); default ignoreErrors swallows.
+    try percy.screenshot(name: "abc")
+  }
+}

--- a/percy-xcui/Tests/PercyXcuiTests/CliWrapperTests.swift
+++ b/percy-xcui/Tests/PercyXcuiTests/CliWrapperTests.swift
@@ -1,0 +1,148 @@
+import Foundation
+import Testing
+
+@testable import PercyXcui
+
+/// Serialized because these tests mutate global state: the registered
+/// `URLProtocol` stub and `Log.logLevel`.
+@Suite(.serialized)
+struct CliWrapperTests {
+  init() {
+    StubURLProtocol.register()
+    StubURLProtocol.reset()
+    Log.logLevel = "debug"
+  }
+
+  private func tile() -> Tile {
+    return Tile(
+      content: "abc", statusBarHeight: 44, navBarHeight: 0, headerHeight: 0, footerHeight: 0,
+      fullScreen: false)
+  }
+
+  // MARK: - healthcheck
+
+  @Test func healthcheckSuccessNoVersionHeader() {
+    defer { StubURLProtocol.unregister() }
+    StubURLProtocol.stubs["/percy/healthcheck"] = .init(
+      statusCode: 204, headers: [:], body: nil, error: nil)
+    #expect(CliWrapper().healthcheck() == true)
+  }
+
+  @Test func healthcheckSuccessSupportedVersion() {
+    defer { StubURLProtocol.unregister() }
+    StubURLProtocol.stubs["/percy/healthcheck"] = .init(
+      statusCode: 200, headers: ["X-Percy-Core-Version": "1.30.0"], body: nil, error: nil)
+    #expect(CliWrapper().healthcheck() == true)
+  }
+
+  @Test func healthcheckSuccessMinorBelow24() {
+    defer { StubURLProtocol.unregister() }
+    StubURLProtocol.stubs["/percy/healthcheck"] = .init(
+      statusCode: 200, headers: ["X-Percy-Core-Version": "1.10.0"], body: nil, error: nil)
+    // Still enabled, just an informational message about the minor version.
+    #expect(CliWrapper().healthcheck() == true)
+  }
+
+  @Test func healthcheckUnsupportedMajorVersion() {
+    defer { StubURLProtocol.unregister() }
+    StubURLProtocol.stubs["/percy/healthcheck"] = .init(
+      statusCode: 200, headers: ["X-Percy-Core-Version": "0.99.0"], body: nil, error: nil)
+    #expect(CliWrapper().healthcheck() == false)
+  }
+
+  @Test func healthcheckNonNumericVersion() {
+    defer { StubURLProtocol.unregister() }
+    // Exercises the `Int(...) ?? 0` fallbacks for both components.
+    StubURLProtocol.stubs["/percy/healthcheck"] = .init(
+      statusCode: 200, headers: ["X-Percy-Core-Version": "x.y.z"], body: nil, error: nil)
+    // major parses to 0 -> unsupported.
+    #expect(CliWrapper().healthcheck() == false)
+  }
+
+  @Test func healthcheckTransportError() {
+    defer { StubURLProtocol.unregister() }
+    StubURLProtocol.stubs["/percy/healthcheck"] = .init(
+      statusCode: 0, headers: [:], body: nil, error: URLError(.notConnectedToInternet))
+    #expect(CliWrapper().healthcheck() == false)
+  }
+
+  @Test func healthcheckNoStubConnectionFailure() {
+    defer { StubURLProtocol.unregister() }
+    // No stub registered -> StubURLProtocol simulates a connection failure.
+    #expect(CliWrapper().healthcheck() == false)
+  }
+
+  // MARK: - postScreenshot
+
+  @Test func postScreenshotSuccess() throws {
+    defer { StubURLProtocol.unregister() }
+    StubURLProtocol.stubs["/percy/comparison"] = .init(
+      statusCode: 200, headers: [:], body: Data("{\"link\":\"https://x\"}".utf8), error: nil)
+    let response = try CliWrapper().postScreenshot(
+      name: "abc", tag: ["name": "iPhone"], tiles: [tile()], testCase: "tc", labels: "l1")
+    #expect(response["link"] as? String == "https://x")
+  }
+
+  @Test func postScreenshotSuccessNilOptionalFields() throws {
+    defer { StubURLProtocol.unregister() }
+    StubURLProtocol.stubs["/percy/comparison"] = .init(
+      statusCode: 201, headers: [:], body: Data("{\"link\":\"https://y\"}".utf8), error: nil)
+    let response = try CliWrapper().postScreenshot(name: "abc", tag: [:], tiles: [tile()])
+    #expect(response["link"] as? String == "https://y")
+  }
+
+  @Test func postScreenshotTransportError() {
+    defer { StubURLProtocol.unregister() }
+    StubURLProtocol.stubs["/percy/comparison"] = .init(
+      statusCode: 0, headers: [:], body: nil, error: URLError(.timedOut))
+    #expect(throws: AppPercyError.self) {
+      _ = try CliWrapper().postScreenshot(name: "abc", tag: [:], tiles: [self.tile()])
+    }
+  }
+
+  @Test func postScreenshotNon2xx() {
+    defer { StubURLProtocol.unregister() }
+    StubURLProtocol.stubs["/percy/comparison"] = .init(
+      statusCode: 500, headers: [:], body: Data("err".utf8), error: nil)
+    #expect(throws: AppPercyError.self) {
+      _ = try CliWrapper().postScreenshot(name: "abc", tag: [:], tiles: [self.tile()])
+    }
+  }
+
+  @Test func postScreenshotNilBody() {
+    defer { StubURLProtocol.unregister() }
+    StubURLProtocol.stubs["/percy/comparison"] = .init(
+      statusCode: 200, headers: [:], body: nil, error: nil)
+    // 2xx but no data -> nil-data path -> empty ret -> throws.
+    #expect(throws: AppPercyError.self) {
+      _ = try CliWrapper().postScreenshot(name: "abc", tag: [:], tiles: [self.tile()])
+    }
+  }
+
+  @Test func postScreenshotCorruptedJSON() {
+    defer { StubURLProtocol.unregister() }
+    // Valid UTF-8 but a JSON array, not an object -> jsonObject cast fails.
+    StubURLProtocol.stubs["/percy/comparison"] = .init(
+      statusCode: 200, headers: [:], body: Data("[1,2,3]".utf8), error: nil)
+    #expect(throws: AppPercyError.self) {
+      _ = try CliWrapper().postScreenshot(name: "abc", tag: [:], tiles: [self.tile()])
+    }
+  }
+
+  @Test func postScreenshotNonUTF8Body() {
+    defer { StubURLProtocol.unregister() }
+    // Invalid UTF-8 bytes: exercises the "Unable to decode as UTF-8" debug path,
+    // then JSONSerialization fails -> empty ret -> throws.
+    StubURLProtocol.stubs["/percy/comparison"] = .init(
+      statusCode: 200, headers: [:], body: Data([0xff, 0xfe, 0xfd]), error: nil)
+    #expect(throws: AppPercyError.self) {
+      _ = try CliWrapper().postScreenshot(name: "abc", tag: [:], tiles: [self.tile()])
+    }
+  }
+
+  // Note: the `do/catch` around JSONSerialization.data(withJSONObject:) in
+  // CliWrapper.postScreenshot is defensive. Foundation raises an Objective-C
+  // NSInvalidArgumentException (not a Swift error) for invalid JSON objects, so
+  // that catch block cannot be reached from a unit test without aborting the
+  // process. Those two lines are documented as host-uncovered defensive code.
+}

--- a/percy-xcui/Tests/PercyXcuiTests/GenericProviderTests.swift
+++ b/percy-xcui/Tests/PercyXcuiTests/GenericProviderTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Testing
+
+@testable import PercyXcui
+
+struct GenericProviderTests {
+  @Test func screenshotBuildsTagThenThrowsOnHostCapture() {
+    Log.logLevel = "debug"
+    let provider = GenericProvider()
+    // screenshot() builds the metadata + tag, then captureTiles() calls
+    // ScreenshotController().takeScreenshot() which throws on the non-UIKit
+    // host. This exercises getTag(), statBarHeight() and navBarHeight().
+    #expect(throws: AppPercyError.self) {
+      try provider.screenshot(name: "abc", options: ScreenshotOptions())
+    }
+  }
+
+  @Test func screenshotWithCustomOptions() {
+    let provider = GenericProvider()
+    let options = ScreenshotOptions()
+    options.statusBarHeight = 10
+    options.navigationBarHeight = 20
+    options.testCase = "tc"
+    options.labels = "l1,l2"
+    #expect(throws: AppPercyError.self) {
+      try provider.screenshot(name: "abc", options: options)
+    }
+  }
+}

--- a/percy-xcui/Tests/PercyXcuiTests/Helpers/StubURLProtocol.swift
+++ b/percy-xcui/Tests/PercyXcuiTests/Helpers/StubURLProtocol.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+@testable import PercyXcui
+
+/// A `URLProtocol` subclass that intercepts every request made through
+/// `URLSession.shared` (which `CliWrapper` uses) and returns a canned response
+/// keyed by URL path. Registering a global `URLProtocol` is the supported way
+/// to stub `URLSession.shared` without adding a third-party HTTP-stub
+/// dependency, and lets the unit suite exercise `CliWrapper` on the macOS host.
+final class StubURLProtocol: URLProtocol {
+  /// A canned outcome for a single request.
+  struct Stub {
+    var statusCode: Int
+    var headers: [String: String]
+    var body: Data?
+    var error: Error?
+  }
+
+  /// Maps a URL path (e.g. "/percy/healthcheck") to its canned outcome.
+  static var stubs: [String: Stub] = [:]
+
+  /// Set to simulate a transport-level failure for any unmatched request.
+  static var fallbackError: Error?
+
+  static func reset() {
+    stubs = [:]
+    fallbackError = nil
+  }
+
+  static func register() {
+    URLProtocol.registerClass(StubURLProtocol.self)
+  }
+
+  static func unregister() {
+    URLProtocol.unregisterClass(StubURLProtocol.self)
+    reset()
+  }
+
+  override class func canInit(with request: URLRequest) -> Bool {
+    return true
+  }
+
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    return request
+  }
+
+  override func startLoading() {
+    guard let url = request.url else {
+      client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+      return
+    }
+
+    let stub = StubURLProtocol.stubs[url.path]
+
+    if let error = stub?.error ?? StubURLProtocol.fallbackError {
+      client?.urlProtocol(self, didFailWithError: error)
+      return
+    }
+
+    guard let stub = stub else {
+      // No stub configured: behave like a connection failure.
+      client?.urlProtocol(self, didFailWithError: URLError(.cannotConnectToHost))
+      return
+    }
+
+    if let response = HTTPURLResponse(
+      url: url, statusCode: stub.statusCode, httpVersion: "HTTP/1.1", headerFields: stub.headers) {
+      client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+    }
+
+    if let body = stub.body {
+      client?.urlProtocol(self, didLoad: body)
+    }
+
+    client?.urlProtocolDidFinishLoading(self)
+  }
+
+  override func stopLoading() {
+    // No-op: responses are delivered synchronously in startLoading().
+  }
+}

--- a/percy-xcui/Tests/PercyXcuiTests/Helpers/StubURLProtocol.swift
+++ b/percy-xcui/Tests/PercyXcuiTests/Helpers/StubURLProtocol.swift
@@ -7,7 +7,11 @@ import Foundation
 /// keyed by URL path. Registering a global `URLProtocol` is the supported way
 /// to stub `URLSession.shared` without adding a third-party HTTP-stub
 /// dependency, and lets the unit suite exercise `CliWrapper` on the macOS host.
-final class StubURLProtocol: URLProtocol {
+///
+/// Not marked `final`: it overrides `URLProtocol`'s required `class func`s
+/// (`canInit`/`canonicalRequest`), which cannot be expressed as `static func`,
+/// and SwiftLint's `static_over_final_class` rule would otherwise flag them.
+class StubURLProtocol: URLProtocol {
   /// A canned outcome for a single request.
   struct Stub {
     var statusCode: Int

--- a/percy-xcui/Tests/PercyXcuiTests/MetadataTests.swift
+++ b/percy-xcui/Tests/PercyXcuiTests/MetadataTests.swift
@@ -1,0 +1,304 @@
+import Foundation
+import Testing
+
+@testable import PercyXcui
+
+// swiftlint:disable type_body_length
+struct MetadataTests {
+  // Allows overriding the resolved device name so the scale-dependent helpers
+  // can be exercised deterministically on the host.
+  final class MockMetadata: Metadata {
+    var mockName = "iPhone 14 Pro"
+    override func deviceName() -> String {
+      return mockName
+    }
+  }
+
+  @Test func osName() {
+    #expect(Metadata().osName() == "iOS")
+  }
+
+  @Test func platformVersionIsNonEmptyMajor() {
+    // On the host this resolves to the OS major version string; just assert it
+    // is a parseable, non-empty value.
+    let version = Metadata().platformVersion()
+    #expect(!version.isEmpty)
+    #expect(Int(version) != nil)
+  }
+
+  @Test func orientationDefaultsToPortrait() {
+    #expect(Metadata().orientation() == "portrait")
+  }
+
+  @Test func screenScale() {
+    // Host fallback is 1.
+    #expect(Metadata().screenScale() >= 1)
+  }
+
+  @Test func navBarHeightDefault() {
+    #expect(Metadata().navBarHeight() == 0)
+  }
+
+  @Test func navBarHeightFromOptions() {
+    let options = ScreenshotOptions()
+    options.navigationBarHeight = 100
+    #expect(Metadata(options: options).navBarHeight() == 100)
+  }
+
+  @Test func statBarHeightFromOptions() {
+    let options = ScreenshotOptions()
+    options.statusBarHeight = 77
+    #expect(Metadata(options: options).statBarHeight() == 77)
+  }
+
+  @Test func statBarHeightComputed() {
+    let mock = MockMetadata()
+    mock.mockName = "iPhone 14 Pro"
+    #expect(mock.statBarHeight() == Int(CGFloat(54) * mock.screenScale()))
+  }
+
+  @Test func deviceScreenWidthComputed() {
+    let mock = MockMetadata()
+    mock.mockName = "iPhone 14 Pro"
+    #expect(mock.deviceScreenWidth() == CGFloat(393) * mock.screenScale())
+  }
+
+  @Test func deviceScreenHeightComputed() {
+    let mock = MockMetadata()
+    mock.mockName = "iPhone 14 Pro"
+    #expect(mock.deviceScreenHeight() == CGFloat(852) * mock.screenScale())
+  }
+
+  @Test func deviceNameResolvesViaMachineName() {
+    // machineName() reads utsname; mapToDevice maps it. Either way it returns a
+    // non-empty string on the host runner.
+    #expect(!Metadata().deviceName().isEmpty)
+  }
+
+  @Test func machineNameNonEmpty() {
+    #expect(!Metadata().machineName().isEmpty)
+  }
+
+  @Test func getDefaultStatusBarHeight() {
+    let meta = Metadata()
+    #expect(meta.getDefaultStatusBarHeight(forDevice: "iPhone X") == 44)
+    #expect(meta.getDefaultStatusBarHeight(forDevice: "iPad Air") == 20)
+    #expect(meta.getDefaultStatusBarHeight(forDevice: "unknown") == 44)
+  }
+
+  @Test func mapToDeviceStatusBarAllArms() {
+    let meta = Metadata()
+    #expect(meta.mapToDeviceStatusBar(identifier: "iphone 14 pro") == 54)
+    #expect(meta.mapToDeviceStatusBar(identifier: "iphone 14 pro max") == 54)
+    #expect(meta.mapToDeviceStatusBar(identifier: "iphone 14") == 47)
+    #expect(meta.mapToDeviceStatusBar(identifier: "iphone 14 plus") == 47)
+    #expect(meta.mapToDeviceStatusBar(identifier: "iPhone 13") == 47)
+    #expect(meta.mapToDeviceStatusBar(identifier: "iphone 13 pro") == 47)
+    #expect(meta.mapToDeviceStatusBar(identifier: "iphone 13 pro max") == 47)
+    #expect(meta.mapToDeviceStatusBar(identifier: "iphone 12") == 47)
+    #expect(meta.mapToDeviceStatusBar(identifier: "iphone 12 pro") == 47)
+    #expect(meta.mapToDeviceStatusBar(identifier: "iphone 12 pro max") == 47)
+    #expect(meta.mapToDeviceStatusBar(identifier: "iPhone 12 Mini") == 50)
+    #expect(meta.mapToDeviceStatusBar(identifier: "iphone 11") == 48)
+    #expect(meta.mapToDeviceStatusBar(identifier: "iphone 11 pro") == 44)
+    #expect(meta.mapToDeviceStatusBar(identifier: "iphone 11 pro max") == 44)
+    // default -> getDefaultStatusBarHeight
+    #expect(meta.mapToDeviceStatusBar(identifier: "some ipad") == 20)
+  }
+
+  @Test func mapToDeviceWidthAllArms() {
+    let meta = Metadata()
+    #expect(meta.mapToDeviceWidth(identifier: "iphone 14 pro max") == 430)
+    #expect(meta.mapToDeviceWidth(identifier: "iphone 14 pro") == 393)
+    #expect(meta.mapToDeviceWidth(identifier: "iphone 14 plus") == 428)
+    #expect(meta.mapToDeviceWidth(identifier: "iphone 12 pro max") == 428)
+    #expect(meta.mapToDeviceWidth(identifier: "iphone 13 pro max") == 428)
+    #expect(meta.mapToDeviceWidth(identifier: "iphone 14") == 390)
+    #expect(meta.mapToDeviceWidth(identifier: "iphone 13 pro") == 390)
+    #expect(meta.mapToDeviceWidth(identifier: "iphone 13") == 390)
+    #expect(meta.mapToDeviceWidth(identifier: "iphone 13 mini") == 375)
+    #expect(meta.mapToDeviceWidth(identifier: "iphone 12 mini") == 375)
+    #expect(meta.mapToDeviceWidth(identifier: "iphone 11 pro") == 375)
+    #expect(meta.mapToDeviceWidth(identifier: "iphone 12 pro") == 390)
+    #expect(meta.mapToDeviceWidth(identifier: "iphone 12") == 390)
+    #expect(meta.mapToDeviceWidth(identifier: "iphone 11 pro max") == 418)
+    #expect(meta.mapToDeviceWidth(identifier: "iphone 11") == 414)
+    // default -> host fallback 0
+    #expect(meta.mapToDeviceWidth(identifier: "unknown device") == 0)
+  }
+
+  @Test func mapToDeviceHeightAllArms() {
+    let meta = Metadata()
+    #expect(meta.mapToDeviceHeight(identifier: "iphone 14 pro max") == 932)
+    #expect(meta.mapToDeviceHeight(identifier: "iphone 14 pro") == 852)
+    #expect(meta.mapToDeviceHeight(identifier: "iphone 14 plus") == 926)
+    #expect(meta.mapToDeviceHeight(identifier: "iphone 12 pro max") == 926)
+    #expect(meta.mapToDeviceHeight(identifier: "iphone 13 pro max") == 926)
+    #expect(meta.mapToDeviceHeight(identifier: "iphone 14") == 844)
+    #expect(meta.mapToDeviceHeight(identifier: "iphone 13 pro") == 844)
+    #expect(meta.mapToDeviceHeight(identifier: "iphone 13") == 844)
+    #expect(meta.mapToDeviceHeight(identifier: "iphone 13 mini") == 812)
+    #expect(meta.mapToDeviceHeight(identifier: "iphone 12 mini") == 812)
+    #expect(meta.mapToDeviceHeight(identifier: "iphone 11 pro") == 812)
+    #expect(meta.mapToDeviceHeight(identifier: "iphone 12 pro") == 844)
+    #expect(meta.mapToDeviceHeight(identifier: "iphone 12") == 844)
+    #expect(meta.mapToDeviceHeight(identifier: "iphone 11 pro max") == 896)
+    #expect(meta.mapToDeviceHeight(identifier: "iphone 11") == 896)
+    // default -> host fallback 0
+    #expect(meta.mapToDeviceHeight(identifier: "unknown device") == 0)
+  }
+
+  // swiftlint:disable:next function_body_length
+  @Test func mapToDeviceAllArms() {
+    let meta = Metadata()
+    let expectations: [(String, String)] = [
+      ("iPod5,1", "iPod touch (5th generation)"),
+      ("iPod7,1", "iPod touch (6th generation)"),
+      ("iPod9,1", "iPod touch (7th generation)"),
+      ("iPhone3,1", "iPhone 4"),
+      ("iPhone3,2", "iPhone 4"),
+      ("iPhone3,3", "iPhone 4"),
+      ("iPhone4,1", "iPhone 4s"),
+      ("iPhone5,1", "iPhone 5"),
+      ("iPhone5,2", "iPhone 5"),
+      ("iPhone5,3", "iPhone 5c"),
+      ("iPhone5,4", "iPhone 5c"),
+      ("iPhone6,1", "iPhone 5s"),
+      ("iPhone6,2", "iPhone 5s"),
+      ("iPhone7,2", "iPhone 6"),
+      ("iPhone7,1", "iPhone 6 Plus"),
+      ("iPhone8,1", "iPhone 6s"),
+      ("iPhone8,2", "iPhone 6s Plus"),
+      ("iPhone9,1", "iPhone 7"),
+      ("iPhone9,3", "iPhone 7"),
+      ("iPhone9,2", "iPhone 7 Plus"),
+      ("iPhone9,4", "iPhone 7 Plus"),
+      ("iPhone10,1", "iPhone 8"),
+      ("iPhone10,4", "iPhone 8"),
+      ("iPhone10,2", "iPhone 8 Plus"),
+      ("iPhone10,5", "iPhone 8 Plus"),
+      ("iPhone10,3", "iPhone X"),
+      ("iPhone10,6", "iPhone X"),
+      ("iPhone11,2", "iPhone XS"),
+      ("iPhone11,4", "iPhone XS Max"),
+      ("iPhone11,6", "iPhone XS Max"),
+      ("iPhone11,8", "iPhone XR"),
+      ("iPhone12,1", "iPhone 11"),
+      ("iPhone12,3", "iPhone 11 Pro"),
+      ("iPhone12,5", "iPhone 11 Pro Max"),
+      ("iPhone13,1", "iPhone 12 mini"),
+      ("iPhone13,2", "iPhone 12"),
+      ("iPhone13,3", "iPhone 12 Pro"),
+      ("iPhone13,4", "iPhone 12 Pro Max"),
+      ("iPhone14,4", "iPhone 13 mini"),
+      ("iPhone14,5", "iPhone 13"),
+      ("iPhone14,2", "iPhone 13 Pro"),
+      ("iPhone14,3", "iPhone 13 Pro Max"),
+      ("iPhone14,7", "iPhone 14"),
+      ("iPhone14,8", "iPhone 14 Plus"),
+      ("iPhone15,2", "iPhone 14 Pro"),
+      ("iPhone15,3", "iPhone 14 Pro Max"),
+      ("iPhone8,4", "iPhone SE"),
+      ("iPhone12,8", "iPhone SE (2nd generation)"),
+      ("iPhone14,6", "iPhone SE (3rd generation)"),
+      ("iPad2,1", "iPad 2"),
+      ("iPad2,2", "iPad 2"),
+      ("iPad2,3", "iPad 2"),
+      ("iPad2,4", "iPad 2"),
+      ("iPad3,1", "iPad (3rd generation)"),
+      ("iPad3,2", "iPad (3rd generation)"),
+      ("iPad3,3", "iPad (3rd generation)"),
+      ("iPad3,4", "iPad (4th generation)"),
+      ("iPad3,5", "iPad (4th generation)"),
+      ("iPad3,6", "iPad (4th generation)"),
+      ("iPad6,11", "iPad (5th generation)"),
+      ("iPad6,12", "iPad (5th generation)"),
+      ("iPad7,5", "iPad (6th generation)"),
+      ("iPad7,6", "iPad (6th generation)"),
+      ("iPad7,11", "iPad (7th generation)"),
+      ("iPad7,12", "iPad (7th generation)"),
+      ("iPad11,6", "iPad (8th generation)"),
+      ("iPad11,7", "iPad (8th generation)"),
+      ("iPad12,1", "iPad (9th generation)"),
+      ("iPad12,2", "iPad (9th generation)"),
+      ("iPad13,18", "iPad (10th generation)"),
+      ("iPad13,19", "iPad (10th generation)"),
+      ("iPad4,1", "iPad Air"),
+      ("iPad4,2", "iPad Air"),
+      ("iPad4,3", "iPad Air"),
+      ("iPad5,3", "iPad Air 2"),
+      ("iPad5,4", "iPad Air 2"),
+      ("iPad11,3", "iPad Air (3rd generation)"),
+      ("iPad11,4", "iPad Air (3rd generation)"),
+      ("iPad13,1", "iPad Air (4th generation)"),
+      ("iPad13,2", "iPad Air (4th generation)"),
+      ("iPad13,16", "iPad Air (5th generation)"),
+      ("iPad13,17", "iPad Air (5th generation)"),
+      ("iPad2,5", "iPad mini"),
+      ("iPad2,6", "iPad mini"),
+      ("iPad2,7", "iPad mini"),
+      ("iPad4,4", "iPad mini 2"),
+      ("iPad4,5", "iPad mini 2"),
+      ("iPad4,6", "iPad mini 2"),
+      ("iPad4,7", "iPad mini 3"),
+      ("iPad4,8", "iPad mini 3"),
+      ("iPad4,9", "iPad mini 3"),
+      ("iPad5,1", "iPad mini 4"),
+      ("iPad5,2", "iPad mini 4"),
+      ("iPad11,1", "iPad mini (5th generation)"),
+      ("iPad11,2", "iPad mini (5th generation)"),
+      ("iPad14,1", "iPad mini (6th generation)"),
+      ("iPad14,2", "iPad mini (6th generation)"),
+      ("iPad6,3", "iPad Pro (9.7-inch)"),
+      ("iPad6,4", "iPad Pro (9.7-inch)"),
+      ("iPad7,3", "iPad Pro (10.5-inch)"),
+      ("iPad7,4", "iPad Pro (10.5-inch)"),
+      ("iPad8,1", "iPad Pro (11-inch) (1st generation)"),
+      ("iPad8,2", "iPad Pro (11-inch) (1st generation)"),
+      ("iPad8,3", "iPad Pro (11-inch) (1st generation)"),
+      ("iPad8,4", "iPad Pro (11-inch) (1st generation)"),
+      ("iPad8,9", "iPad Pro (11-inch) (2nd generation)"),
+      ("iPad8,10", "iPad Pro (11-inch) (2nd generation)"),
+      ("iPad13,4", "iPad Pro (11-inch) (3rd generation)"),
+      ("iPad13,5", "iPad Pro (11-inch) (3rd generation)"),
+      ("iPad13,6", "iPad Pro (11-inch) (3rd generation)"),
+      ("iPad13,7", "iPad Pro (11-inch) (3rd generation)"),
+      ("iPad14,3", "iPad Pro (11-inch) (4th generation)"),
+      ("iPad14,4", "iPad Pro (11-inch) (4th generation)"),
+      ("iPad6,7", "iPad Pro (12.9-inch) (1st generation)"),
+      ("iPad6,8", "iPad Pro (12.9-inch) (1st generation)"),
+      ("iPad7,1", "iPad Pro (12.9-inch) (2nd generation)"),
+      ("iPad7,2", "iPad Pro (12.9-inch) (2nd generation)"),
+      ("iPad8,5", "iPad Pro (12.9-inch) (3rd generation)"),
+      ("iPad8,6", "iPad Pro (12.9-inch) (3rd generation)"),
+      ("iPad8,7", "iPad Pro (12.9-inch) (3rd generation)"),
+      ("iPad8,8", "iPad Pro (12.9-inch) (3rd generation)"),
+      ("iPad8,11", "iPad Pro (12.9-inch) (4th generation)"),
+      ("iPad8,12", "iPad Pro (12.9-inch) (4th generation)"),
+      ("iPad13,8", "iPad Pro (12.9-inch) (5th generation)"),
+      ("iPad13,9", "iPad Pro (12.9-inch) (5th generation)"),
+      ("iPad13,10", "iPad Pro (12.9-inch) (5th generation)"),
+      ("iPad13,11", "iPad Pro (12.9-inch) (5th generation)"),
+      ("iPad14,5", "iPad Pro (12.9-inch) (6th generation)"),
+      ("iPad14,6", "iPad Pro (12.9-inch) (6th generation)"),
+      ("AppleTV5,3", "Apple TV"),
+      ("AppleTV6,2", "Apple TV 4K"),
+      ("AudioAccessory1,1", "HomePod"),
+      ("AudioAccessory5,1", "HomePod mini"),
+      ("totally-unknown", "totally-unknown")
+    ]
+    for (identifier, expected) in expectations {
+      #expect(meta.mapToDevice(identifier: identifier) == expected, "for \(identifier)")
+    }
+  }
+
+  @Test func mapToDeviceSimulatorArm() {
+    let meta = Metadata()
+    // The i386/x86_64/arm64 arm recurses with SIMULATOR_MODEL_IDENTIFIER
+    // (unset in tests -> "iOS" -> default arm). Result is prefixed.
+    for arch in ["i386", "x86_64", "arm64"] {
+      #expect(meta.mapToDevice(identifier: arch).hasPrefix("Simulator "))
+    }
+  }
+}
+// swiftlint:enable type_body_length

--- a/percy-xcui/Tests/PercyXcuiTests/SupportTypesTests.swift
+++ b/percy-xcui/Tests/PercyXcuiTests/SupportTypesTests.swift
@@ -1,0 +1,121 @@
+import Foundation
+import Testing
+
+@testable import PercyXcui
+
+struct TileTests {
+  @Test func getTileJSONSingle() throws {
+    let tile = Tile(
+      content: "data", statusBarHeight: 44, navBarHeight: 1, headerHeight: 2, footerHeight: 3,
+      fullScreen: true)
+    let json = try #require(Tile.getTileJSON(tiles: [tile]) as? [[String: Any]])
+    #expect(json.count == 1)
+    #expect(json[0]["content"] as? String == "data")
+    #expect(json[0]["statusBarHeight"] as? Int == 44)
+    #expect(json[0]["navBarHeight"] as? Int == 1)
+    #expect(json[0]["headerHeight"] as? Int == 2)
+    #expect(json[0]["footerHeight"] as? Int == 3)
+    #expect(json[0]["fullscreen"] as? Bool == true)
+  }
+
+  @Test func getTileJSONMultiple() throws {
+    let tiles = [
+      Tile(content: "a", statusBarHeight: 0, navBarHeight: 0, headerHeight: 0, footerHeight: 0,
+        fullScreen: false),
+      Tile(content: "b", statusBarHeight: 0, navBarHeight: 0, headerHeight: 0, footerHeight: 0,
+        fullScreen: false)
+    ]
+    let json = try #require(Tile.getTileJSON(tiles: tiles) as? [[String: Any]])
+    #expect(json.count == 2)
+  }
+
+  @Test func getTileJSONEmpty() throws {
+    let json = try #require(Tile.getTileJSON(tiles: []) as? [[String: Any]])
+    #expect(json.isEmpty)
+  }
+}
+
+struct ScreenshotOptionsTests {
+  @Test func defaults() {
+    let options = ScreenshotOptions()
+    #expect(options.statusBarHeight == -1)
+    #expect(options.navigationBarHeight == -1)
+    #expect(options.fullScreen == false)
+    #expect(options.testCase == nil)
+    #expect(options.labels == nil)
+  }
+
+  @Test func mutation() {
+    let options = ScreenshotOptions()
+    options.statusBarHeight = 10
+    options.navigationBarHeight = 20
+    options.fullScreen = true
+    options.testCase = "tc"
+    options.labels = "a,b"
+    #expect(options.statusBarHeight == 10)
+    #expect(options.navigationBarHeight == 20)
+    #expect(options.fullScreen == true)
+    #expect(options.testCase == "tc")
+    #expect(options.labels == "a,b")
+  }
+}
+
+@Suite(.serialized)
+struct LoggerTests {
+  @Test func info() {
+    Log.logLevel = "info"
+    Log.info(msg: "an info message")
+    Log.logLevel = "info"
+  }
+
+  @Test func errorAlwaysLogs() {
+    Log.logLevel = "info"
+    Log.error(msg: "an error message")
+  }
+
+  @Test func debugSuppressedWhenNotDebugLevel() {
+    Log.logLevel = "info"
+    // Returns early without logging (exercises the guard's true branch).
+    Log.debug(msg: "should be suppressed")
+  }
+
+  @Test func debugEmittedWhenDebugLevel() {
+    Log.logLevel = "debug"
+    Log.debug(msg: "should be emitted")
+    Log.logLevel = "info"
+  }
+
+  @Test func logfmtDefaultLevel() {
+    Log.logfmt(msg: "direct logfmt call")
+  }
+}
+
+struct ErrorsTests {
+  @Test func screenshotErrorCase() {
+    let error: AppPercyError = .screenshotError("boom")
+    guard case let .screenshotError(message) = error else {
+      Issue.record("Expected screenshotError")
+      return
+    }
+    #expect(message == "boom")
+  }
+
+  @Test func postScreenshotErrorCase() {
+    let error: AppPercyError = .postScreenshotError("nope")
+    guard case let .postScreenshotError(message) = error else {
+      Issue.record("Expected postScreenshotError")
+      return
+    }
+    #expect(message == "nope")
+  }
+}
+
+struct ScreenshotControllerTests {
+  @Test func takeScreenshotThrowsOnHost() {
+    // On the non-UIKit host the controller shim throws (real capture needs the
+    // iOS runtime). On an iOS simulator build this same call captures a screen.
+    #expect(throws: AppPercyError.self) {
+      _ = try ScreenshotController().takeScreenshot()
+    }
+  }
+}


### PR DESCRIPTION
This SDK had **no test target** and wouldn't even `swift build` on a non-iOS host (unconditional `UIKit`/`XCTest` imports). This PR makes the package host-buildable and adds a real coverage gate.

## Source changes (behavior-preserving)
`#if canImport(UIKit)` guards in `Metadata.swift`, `GenericProvider.swift`, `ScreenshotController.swift`. **Every iOS branch is the original code, untouched** — guards only add `#else` host fallbacks (e.g. `screenScale()` → `1` on host, a `ScreenshotController` host shim that throws the same `AppPercyError`). iOS behavior is preserved by construction (iOS always takes the `canImport(UIKit)` branch).

## Tests + gate
- 53 host tests (Swift Testing) in `percy-xcui/Tests/PercyXcuiTests/`, covering AppPercy, CliWrapper (HTTP via a `URLProtocol` stub — no new deps), every `Metadata.mapToDevice*` arm, Tile/Options/Logger/Errors/ScreenshotController.
- `Scripts/coverage.sh` → `swift test --enable-code-coverage` + `llvm-cov`, **floor 95.0%** (ignore-regex drops only test files/`.build`, never SDK source — no inflation).
- `.github/workflows/test.yml`: blocking **`unit-coverage`** job (host, runs the gate) + non-blocking **`simulator-uitests`** job that runs the existing XCUITests on an iOS simulator with coverage to reach the screenshot-capture lines toward ~100% combined.

## Coverage (local host)
**95.69% lines (489/511), 53/53 pass.** Per-file: Metadata / Logger / ScreenshotController / ScreenshotOptions / Tile = 100%; AppPercy 100% lines; CliWrapper 97.9%; GenericProvider 60.9%.

## Honest scope note
The 22 uncovered host lines are: ~18 in `GenericProvider.screenshot/captureTiles` (the real iOS screenshot capture — covered by the simulator job, not host-reachable) and 4 defensive lines in CliWrapper (a JSON catch only triggerable via an uncatchable ObjC `NSException`, and a nil-`data` branch `URLSession` never produces). These need the iOS runtime or are genuinely unreachable — **no exclusions used to hide them**; the gate floor reflects the honest host maximum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)