### PR TITLE
ci: run tests against an unpublished @percy/cli branch (PER-9772)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,12 @@ on:
     branches: ["master", "main"]
   pull_request:
     branches: ["master", "main"]
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: '@percy/cli branch to test against'
+        required: false
+        default: master
 
 jobs:
   # Blocking gate: builds the SwiftPM package on the macOS host and runs the
@@ -21,6 +27,34 @@ jobs:
         run: |
           swift --version
           xcodebuild -version || true
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - uses: actions-ecosystem/action-regex-match@v2
+        id: regex-match
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        with:
+          text: ${{ github.event.inputs.branch }}
+          regex: '^[a-zA-Z0-9_/\-]+$'
+      - name: Break on invalid branch name
+        if: ${{ github.event_name == 'workflow_dispatch' && steps.regex-match.outputs && steps.regex-match.outputs.match == '' }}
+        run: exit 1
+      - name: Set up @percy/cli from git
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          BRANCH: ${{ github.event.inputs.branch }}
+          WORKSPACE: ${{ github.workspace }}
+        run: |
+          cd /tmp
+          git clone --branch "$BRANCH" --depth 1 https://github.com/percy/cli
+          cd cli
+          yarn
+          yarn build
+          yarn global:link
+          echo "$(yarn global bin)" >> "$GITHUB_PATH"
+          export PATH="$(yarn global bin):$PATH"
+          percy --version
 
       - name: Build package
         run: swift build


### PR DESCRIPTION
Adds CLI-branch injection (workflow_dispatch); built percy on PATH. Part of PER-9772.